### PR TITLE
Create a menu in J3.2 alpha

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -37,7 +37,7 @@ class modMenuwrenchHelper {
 	function getBranches() {
 		$renderedItems     = $this->params->get('renderedItems');
 		$showSubmenu = $this->params->get('showSubmenu');
-		$hideSubmenu  = $this->params->get('hideSubmenu');
+		$hideSubmenu  = $this->params->get('hideSubmenu', array());
 		// http://stackoverflow.com/questions/3787669/how-to-get-specific-menu-items-from-joomla/10218419#10218419
 		$items = $this->menu->getItems(NULL, NULL);
 


### PR DESCRIPTION
```
Warning: str_split(): The length of each segment must be greater than zero in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 50

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99

Warning: in_array() expects parameter 2 to be array, boolean given in C:\xampp\htdocs\joomla32\modules\mod_menuwrench\helper.php on line 99
```
