### PR TITLE
Fix for HTML validation errors on closing <a> tags

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -322,7 +322,7 @@ class modMenuwrenchHelper
 		switch ($item->type)
 		{
 			case 'alias':
-				$output = $itemOpenTag . '<a ' . $browserNav . ' href="index.php?Itemid=' . $item->params->get('aliasoptions') . '"/>' . $item->title . '</a>';
+				$output = $itemOpenTag . '<a ' . $browserNav . ' href="index.php?Itemid=' . $item->params->get('aliasoptions') . '">' . $item->title . '</a>';
 				break;
 
 			case 'separator':
@@ -332,17 +332,17 @@ class modMenuwrenchHelper
 			case 'url' :
 				if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false))
 				{
-					$output = $itemOpenTag . '<a ' . $browserNav . ' href="' . JRoute::_($item->link . '&Itemid=' . $item->id) . '"/>' . $item->title . '</a>';
+					$output = $itemOpenTag . '<a ' . $browserNav . ' href="' . JRoute::_($item->link . '&Itemid=' . $item->id) . '">' . $item->title . '</a>';
 				}
 				else
 				{
-					$output = $itemOpenTag . '<a ' . $browserNav . ' href="' . $item->link . '"/>' . $item->title . '</a>';
+					$output = $itemOpenTag . '<a ' . $browserNav . ' href="' . $item->link . '">' . $item->title . '</a>';
 				}
 				break;
 
 			default:
 				$item->link = strpos($item->link, 'Itemid') ? $item->link : $item->link . '&Itemid=' . $item->id;
-				$output     = $itemOpenTag . '<a ' . $browserNav . ' href="' . JRoute::_($item->link) . '"/>' . $item->title . '</a>';
+				$output     = $itemOpenTag . '<a ' . $browserNav . ' href="' . JRoute::_($item->link) . '">' . $item->title . '</a>';
 				break;
 		}
 


### PR DESCRIPTION
Resolves html validation errors: "Self-closing syntax (/>) used on a non-void HTML element".
Links were rendered as `<a href="index.php"/>Some link</a>` which is not HTML valid.
